### PR TITLE
feat: add season snapshot block and archive standings support

### DIFF
--- a/basebelles.css
+++ b/basebelles.css
@@ -6,7 +6,6 @@
 :root {
 	--bb-sandstone-cream: #f3efe0;
 	--bb-wine-red: #84172c;
-	/* Darker wine for large banners (e.g. season header); optional elsewhere */
 	--bb-wine-red-banner: #6d1a22;
 	--bb-deep-navy: #002d62;
 	--bb-slate-blue: #00385d;
@@ -99,6 +98,11 @@ button, .button, .faux-button, .wp-block-button__link, .wp-block-file .wp-block-
 thead {
 	background-color: var(--bb-deep-navy);
 	color: var(--bb-sandstone-cream);
+}
+
+/* Season Snapshot block: optional layout hooks when not using block CSS alone */
+.basebelles-season-stats-header .season-stats-inner {
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
 }
 
 a.wp-block-latest-posts__post-title {

--- a/basebelles.php
+++ b/basebelles.php
@@ -133,12 +133,16 @@ class Basebelles {
 	 * @return void
 	 */
 	public function pre_get_posts( $query ) {
+		if ( is_admin() || ! $query->is_main_query() ) {
+			return;
+		}
+
 		// Only modify the main query on the frontend for your specific taxonomy archive
-		if ( ! is_admin() && $query->is_main_query() && is_tax( 'season-type' ) ) {
-			$year = get_query_var( 'year' );
+		if ( is_tax( 'season-type' ) ) {
+			$year = get_query_var( 'season_year' );
 			if ( ! $year ) {
 				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				$year = isset( $_GET['year'] ) ? (int) wp_unslash( $_GET['year'] ) : false;
+				$year = isset( $_GET['season_year'] ) ? (int) wp_unslash( $_GET['season_year'] ) : false;
 			}
 
 			if ( $year && is_numeric( $year ) ) {

--- a/blocks/class-blocks.php
+++ b/blocks/class-blocks.php
@@ -44,6 +44,7 @@ class Basebelles_Blocks {
 		register_block_type( __DIR__ . '/standings' );
 		register_block_type( __DIR__ . '/today-game' );
 		register_block_type( __DIR__ . '/streamable' );
+		register_block_type( __DIR__ . '/season-stats-header' );
 	}
 
 	/**
@@ -59,6 +60,7 @@ class Basebelles_Blocks {
 		wp_register_style( 'basebelles-standings-style', plugin_dir_url( __FILE__ ) . 'standings/block.css', $deps, self::$version );
 		wp_register_style( 'basebelles-today-game-style', plugin_dir_url( __FILE__ ) . 'today-game/block.css', $deps, self::$version );
 		wp_register_style( 'basebelles-streamable-style', plugin_dir_url( __FILE__ ) . 'streamable/block.css', $deps, self::$version );
+		wp_register_style( 'basebelles-season-stats-header-style', plugin_dir_url( __FILE__ ) . 'season-stats-header/block.css', $deps, self::$version );
 	}
 
 	/**
@@ -96,6 +98,7 @@ class Basebelles_Blocks {
 		wp_enqueue_style( 'basebelles-standings-style', plugin_dir_url( __FILE__ ) . 'standings/block.css', $deps, self::$version );
 		wp_enqueue_style( 'basebelles-today-game-style', plugin_dir_url( __FILE__ ) . 'today-game/block.css', $deps, self::$version );
 		wp_enqueue_style( 'basebelles-streamable-style', plugin_dir_url( __FILE__ ) . 'streamable/block.css', $deps, self::$version );
+		wp_enqueue_style( 'basebelles-season-stats-header-style', plugin_dir_url( __FILE__ ) . 'season-stats-header/block.css', $deps, self::$version );
 	}
 }
 

--- a/blocks/season-header/block.json
+++ b/blocks/season-header/block.json
@@ -4,7 +4,7 @@
     "description": "Displays the current season.",
     "style": [ "basebelles-style", "file:./block.css" ],
     "category": "basebelles",
-    "icon": "status",
+    "icon": "slides",
     "keywords": ["season", "guardians", "baseball"],
     "acf": {
         "mode": "preview",

--- a/blocks/season-header/render.php
+++ b/blocks/season-header/render.php
@@ -13,8 +13,9 @@ if ( ! function_exists( 'get_field' ) ) {
 // ACF Group: Season Info (group_69cd81d38a341)
 $season_settings   = get_field( 'season_settings', 'option' );
 $default_start_end = array(
-	'start' => 'TBD',
-	'end'   => 'TBD',
+	'start'  => 'TBD',
+	'end'    => 'TBD',
+	'record' => '',
 );
 $season_details    = array(
 	'spring_training' => get_field( 'spring_training', 'option' ) ?? $default_start_end,
@@ -86,7 +87,7 @@ if ( 'postSeason' === $season_type && $season_data['post_season']['end'] < wp_da
 	</div>
 	<?php if ( 'offSeason' === $season_type ) { ?>
 			<div class="off-season-container">
-				<img src=class="off-season-image" src="<?php echo esc_url( $off_season ); ?>" alt="Off Season - See you in the spring!" />
+				<img class="off-season-image" src="<?php echo esc_url( $off_season ); ?>" alt="Off Season - See you in the spring!" />
 			</div>
 	<?php } else { ?>
 		<?php foreach ( $season_data as $season_type => $season ) { ?>

--- a/blocks/season-header/render.php
+++ b/blocks/season-header/render.php
@@ -12,6 +12,7 @@ if ( ! function_exists( 'get_field' ) ) {
 
 // ACF Group: Season Info (group_69cd81d38a341)
 $season_settings   = get_field( 'season_settings', 'option' );
+$season_settings   = $season_settings ? $season_settings : array();
 $default_start_end = array(
 	'start'  => 'TBD',
 	'end'    => 'TBD',

--- a/blocks/season-stats-header/block.css
+++ b/blocks/season-stats-header/block.css
@@ -1,0 +1,112 @@
+/* Season Snapshot — taxonomy archive stat bar (City Connect palette via :root in basebelles.css) */
+
+.basebelles-season-stats-header {
+	position: relative;
+	margin-bottom: 1.5rem;
+}
+
+.basebelles-season-stats-header--placeholder,
+.basebelles-season-stats-header--empty,
+.basebelles-season-stats-header--error {
+	background: var(--bb-wine-red, #84172c);
+	color: var(--bb-sandstone-cream, #f3efe0);
+	padding: 1rem 1.25rem;
+	border-radius: 4px;
+}
+
+.basebelles-season-stats-header--placeholder p,
+.basebelles-season-stats-header--empty p,
+.basebelles-season-stats-header--error p {
+	margin: 0;
+	font-size: 0.95rem;
+}
+
+.season-stats-inner {
+	position: relative;
+	overflow: hidden;
+	background-color: var(--bb-wine-red, #84172c);
+	color: var(--bb-sandstone-cream, #f3efe0);
+	border-radius: 4px;
+	padding: 1.25rem 1rem;
+}
+
+/* Ghost layer (~10%): desert / ballpark hint — swap for Goodyear / Progressive photos in theme if desired */
+.season-stats-ghost {
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	opacity: 0.1;
+	background-size: cover;
+	background-position: center;
+}
+
+.basebelles-season-stats-header--spring .season-stats-ghost {
+	background-image: radial-gradient(ellipse 90% 70% at 50% 100%, #f3efe0 0%, transparent 55%);
+}
+
+.basebelles-season-stats-header--regular .season-stats-ghost {
+	background-image: radial-gradient(ellipse 75% 60% at 70% 30%, #f3efe0 0%, transparent 50%),
+		linear-gradient(180deg, rgba(0, 45, 98, 0.35) 0%, transparent 45%);
+}
+
+.basebelles-season-stats-header--postseason .season-stats-ghost {
+	background-image: radial-gradient(ellipse 80% 55% at 50% 0%, #f3efe0 0%, transparent 50%),
+		linear-gradient(0deg, rgba(0, 0, 0, 0.2) 0%, transparent 40%);
+}
+
+.season-stats-grid {
+	position: relative;
+	z-index: 1;
+	display: grid;
+	grid-template-columns: repeat(4, minmax(0, 1fr));
+	gap: 1rem 1.25rem;
+	align-items: start;
+}
+
+.season-stats-cell {
+	display: flex;
+	flex-direction: column;
+	gap: 0.35rem;
+	min-width: 0;
+}
+
+.season-stats-label {
+	font-size: 0.7rem;
+	text-transform: uppercase;
+	letter-spacing: 0.06em;
+	opacity: 0.9;
+	font-weight: 600;
+}
+
+.season-stats-value {
+	font-size: 1.15rem;
+	font-weight: 700;
+	line-height: 1.25;
+	word-break: break-word;
+}
+
+/* Mirror Season Header “over” treatment for completed seasons */
+.basebelles-season-stats-header.is-past .season-stats-value {
+	text-decoration: line-through;
+	opacity: 0.65;
+}
+
+.basebelles-season-stats-header.is-past .season-stats-label {
+	opacity: 0.75;
+}
+
+@media screen and (max-width: 960px) {
+	.season-stats-grid {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
+
+@media screen and (max-width: 520px) {
+	.season-stats-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.season-stats-value {
+		font-size: 1.05rem;
+	}
+}

--- a/blocks/season-stats-header/block.json
+++ b/blocks/season-stats-header/block.json
@@ -1,0 +1,17 @@
+{
+    "name": "acf/basebelles-season-stats-header",
+    "title": "Season Snapshot",
+    "description": "Summary stats bar for season-type archive pages (record, rank, run diff).",
+    "style": [ "basebelles-style", "file:./block.css" ],
+    "category": "basebelles",
+    "icon": "chart-area",
+    "keywords": [ "season", "stats", "archive", "guardians" ],
+    "acf": {
+        "mode": "preview",
+        "renderTemplate": "render.php"
+    },
+    "supports": {
+        "align": true,
+        "anchor": true
+    }
+}

--- a/blocks/season-stats-header/render.php
+++ b/blocks/season-stats-header/render.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Season Snapshot — stats bar for season-type taxonomy archives.
+ *
+ * @package Base*Belles
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! function_exists( 'basebelles_season_snapshot_context_note' ) ) {
+	/**
+	 * Standings-derived contextual line by season segment.
+	 *
+	 * @param array  $stats    Archive stats from API.
+	 * @param string $api_type API season type.
+	 * @return string
+	 */
+	function basebelles_season_snapshot_context_note( $stats, $api_type ) {
+		$l10 = (string) ( $stats['last_ten'] ?? null );
+		$stk = (string) ( $stats['streak'] ?? null );
+		$gb  = (string) ( $stats['games_back'] ?? null );
+
+		// If the value is NOT - then don't show it
+		if ( ! is_null( $gb ) && '-' !== $gb ) {
+			// translators: %1$s is the games back
+			$gb = sprintf( __( 'GB: %1$s', 'basebelles' ), $gb );
+		}
+		if ( ! is_null( $l10 ) && '-' !== $l10 ) {
+			// translators: %1$s is the last ten record
+			$l10 = sprintf( __( 'L10: %1$s', 'basebelles' ), $l10 );
+		}
+		if ( ! is_null( $stk ) && '-' !== $stk ) {
+			// translators: %1$s is the streak code
+			$stk = sprintf( __( 'STK: %1$s', 'basebelles' ), $stk );
+		}
+
+		$context_note = array( $gb, $l10, $stk );
+
+		foreach ( $context_note as $key => $note ) {
+			if ( '-' === $note ) {
+				unset( $context_note[ $key ] );
+			}
+		}
+
+		return implode( ' <br /> ', $context_note );
+	}
+}
+
+if ( ! class_exists( 'Basebelles_API' ) ) {
+	if ( is_admin() ) {
+		echo '<div class="basebelles-season-stats-header basebelles-season-stats-header--placeholder"><p>API unavailable.</p></div>';
+	}
+	return;
+}
+
+if ( is_admin() ) {
+	echo '<div class="basebelles-season-stats-header basebelles-season-stats-header--placeholder"><p>Season Snapshot appears on <strong>season-type</strong> archives with <code>?season_year=</code>.</p></div>';
+	return;
+}
+
+if ( ! is_tax( 'season-type' ) ) {
+	return;
+}
+
+// Get the current year from ACF Options
+$season_settings = get_field( 'season_settings', 'option' ) ?? array();
+$current_season  = (int) ( $season_settings['current_season'] ?? (int) gmdate( 'Y' ) );
+
+$queried_season_term = get_queried_object();
+if ( ! $queried_season_term || empty( $queried_season_term->slug ) ) {
+	return;
+}
+
+$slug_to_type = array(
+	'spring-training' => 'springTraining',
+	'regular-season'  => 'regularSeason',
+	'post-season'     => 'postseason',
+);
+
+$api_type = $slug_to_type[ $queried_season_term->slug ] ?? 'regularSeason';
+
+$season_year = (int) get_query_var( 'season_year' );
+if ( $season_year < 1900 ) {
+	$season_year = (int) gmdate( 'Y' );
+}
+
+$api     = Basebelles_API::get_instance();
+$stats   = $api->get_season_archive_stats( $season_year, $api_type );
+$is_past = $season_year < (int) wp_date( 'Y' );
+
+if ( is_wp_error( $stats ) ) {
+	$code = $stats->get_error_code();
+	if ( 'basebelles_api_future' === $code || 'basebelles_api_empty' === $code || 'basebelles_api_postseason_empty' === $code || 'basebelles_api_team_missing' === $code ) {
+		printf(
+			'<div class="basebelles-season-stats-header basebelles-season-stats-header--empty%s" role="status"><p class="season-stats-coming-soon">%s</p></div>',
+			$is_past ? ' is-past' : '',
+			esc_html__( 'Coming soon — stats are not available for this season yet.', 'basebelles' )
+		);
+		return;
+	}
+	echo '<div class="basebelles-season-stats-header basebelles-season-stats-header--error" role="alert"><p>';
+	echo esc_html( $stats->get_error_message() );
+	echo '</p></div>';
+	return;
+}
+
+$record_label = sprintf( '%d – %d', (int) ( $stats['wins'] ?? 0 ), (int) ( $stats['losses'] ?? 0 ) );
+$context_note = basebelles_season_snapshot_context_note( $stats, $api_type );
+
+$class_season_type = 'basebelles-season-stats-header-regular';
+if ( 'springTraining' === $api_type ) {
+	$class_season_type = 'basebelles-season-stats-header-spring';
+} elseif ( 'postseason' === $api_type ) {
+	$class_season_type = 'basebelles-season-stats-header-postseason';
+}
+
+$class_current_season = ( gmdate( 'Y' ) === $current_season ) ? 'is-current' : '';
+
+$classes = array(
+	'basebelles-season-stats-header',
+	$class_season_type,
+	$class_current_season,
+);
+if ( $is_past ) {
+	$classes[] = 'is-past';
+}
+
+printf(
+	'<div class="%1$s"><div class="season-stats-inner"><div class="season-stats-ghost" aria-hidden="true"></div><div class="season-stats-grid">',
+	esc_attr( implode( ' ', $classes ) )
+);
+?>
+	<div class="season-stats-cell season-stats-record">
+		<span class="season-stats-label"><?php esc_html_e( 'Record', 'basebelles' ); ?></span>
+		<span class="season-stats-value"><?php echo esc_html( $record_label ); ?></span>
+	</div>
+	<div class="season-stats-cell season-stats-rank">
+		<span class="season-stats-label"><?php esc_html_e( 'Rank', 'basebelles' ); ?></span>
+		<span class="season-stats-value"><?php echo esc_html( (string) ( $stats['rank'] ?? '—' ) ); ?></span>
+	</div>
+	<div class="season-stats-cell season-stats-diff">
+		<span class="season-stats-label"><?php esc_html_e( 'Run diff', 'basebelles' ); ?></span>
+		<span class="season-stats-value"><?php echo esc_html( (string) ( $stats['run_diff'] ?? '—' ) ); ?></span>
+	</div>
+	<div class="season-stats-cell season-stats-context">
+		<span class="season-stats-label"><?php esc_html_e( 'Snapshot', 'basebelles' ); ?></span>
+		<span class="season-stats-value"><?php echo wp_kses_post( $context_note ); ?></span>
+	</div>
+<?php
+echo '</div></div></div>';

--- a/blocks/today-game/block.css
+++ b/blocks/today-game/block.css
@@ -1,11 +1,13 @@
 /* Guardians Today's Game Block */
 .basebelles-today-game {
+	box-sizing: border-box;
 	padding: 10px;
 	background: #fff;
 	color: var(--bb-deep-navy);
 	border: 1px solid var(--bb-slate-blue);
 	font-family: sans-serif;
-	max-width: 75%;
+	max-width: 50%;
+	margin-inline: auto;
 }
 
 .basebelles-today-game.placeholder {

--- a/blocks/today-game/block.css
+++ b/blocks/today-game/block.css
@@ -118,3 +118,11 @@
 	text-align: center;
 	padding-bottom: 10px;
 }
+
+.game-meta .guards-win {
+	color: var(--bb-green);
+}
+
+.game-meta .oppo-win {
+	color: var(--bb-red);
+}

--- a/blocks/today-game/render.php
+++ b/blocks/today-game/render.php
@@ -51,6 +51,9 @@ if ( is_wp_error( $schedule ) ) {
 			$away_pitcher = $game['away_pitcher'];
 			$home_pitcher = $game['home_pitcher'];
 
+			// Are the Guards the home team or away team?
+			$home_or_away = ( 'CLE' === $game['home_team']['abbreviation'] ) ? 'home' : 'away';
+
 			if ( empty( $away_pitcher ) ) {
 				$away_pitcher = array(
 					'name'   => 'TBD',
@@ -175,12 +178,23 @@ if ( is_wp_error( $schedule ) ) {
 								</strong>
 								<?php
 							} elseif ( ! empty( $game['scores']['isFinal'] ) ) {
+								$winner = $home_or_away === $game['scores']['winner'] ? 'guards-win' : 'oppo-win';
 								?>
-								<strong>
+								<strong class="<?php echo esc_attr( $winner ); ?>">
+									<?php
+									if ( 'away' === $game['scores']['winner'] ) {
+										echo esc_html( '&#9756;&nbsp;' );
+									}
+									?>
 									FINAL
 									<?php
 									if ( ! empty( $game['scores']['inning'] ) && $game['scores']['inning'] > 9 ) {
 										echo esc_html( ' / ' . $game['scores']['inning'] );
+									}
+									?>
+									<?php
+									if ( 'home' === $game['scores']['winner'] ) {
+										echo esc_html( '&#9758;&nbsp;' );
 									}
 									?>
 								</strong>

--- a/class-api.php
+++ b/class-api.php
@@ -19,6 +19,8 @@ class Basebelles_API {
 	const AL_LEAGUE_ID      = 103; // American League
 	const CL_LEAGUE_ID      = 114; // Cactus League (spring training)
 	const GUARDIANS_TEAM_ID = 114; // Cleveland Guardians
+	/** Cache TTL for season archive snapshots (past years are immutable). */
+	const API_ARCHIVE_CACHE_TTL = DAY_IN_SECONDS;
 
 	/**
 	 * Singleton instance.
@@ -72,29 +74,121 @@ class Basebelles_API {
 	/**
 	 * Fetch and normalize Guardians standings data.
 	 *
-	 * @param string $season_type The season type.
+	 * @param string   $season_type  The season type.
+	 * @param int|null $season_year  Optional season year; defaults to ACF/options season.
 	 *
 	 * @return array|WP_Error
 	 */
-	public function get_guardians_standings( $season_type = 'regularSeason' ) {
-		$settings  = $this->get_season_settings( $season_type );
-		$league_id = ( 'springTraining' === $season_type ) ? self::CL_LEAGUE_ID : self::AL_LEAGUE_ID;
-		$data      = $this->request_json(
-			'standings',
-			array(
-				'leagueId'       => $league_id,
-				'season'         => $settings['season'],
-				'standingsTypes' => $settings['season_type'],
-				'hydrate'        => 'division',
-			)
+	public function get_guardians_standings( $season_type = 'regularSeason', $season_year = null ) {
+		$settings = $this->get_season_settings( $season_type );
+		$year     = ( null !== $season_year && is_numeric( $season_year ) ) ? (int) $season_year : (int) $settings['season'];
+		if ( $year < 1900 ) {
+			$year = (int) gmdate( 'Y' );
+		}
+
+		return $this->fetch_guardians_standings_normalized( $year, $settings['season_type'], null, self::API_CACHE_TTL );
+	}
+
+	/**
+	 * Standings snapshot for taxonomy archives (cached 24h; optional date for Spring Training freeze).
+	 *
+	 * @param int    $year        Season year (e.g. 2024).
+	 * @param string $season_type springTraining|regularSeason|wildCard|postseason.
+	 * @return array|WP_Error Normalized stats array, or error if unavailable.
+	 */
+	public function get_season_archive_stats( $year, $season_type ) {
+		$year = (int) $year;
+		if ( $year < 1900 ) {
+			return new WP_Error( 'basebelles_api_bad_year', 'Invalid season year.' );
+		}
+
+		$current_year = (int) gmdate( 'Y' );
+		if ( $year > $current_year ) {
+			return new WP_Error( 'basebelles_api_future', 'Season data is not available yet.' );
+		}
+
+		$allowed_types = array(
+			'springTraining',
+			'regularSeason',
+			'wildCard',
+			'postseason',
 		);
+		if ( ! in_array( $season_type, $allowed_types, true ) ) {
+			$season_type = 'regularSeason';
+		}
+
+		$date = null;
+		if ( 'springTraining' === $season_type ) {
+			$date = $this->get_spring_training_freeze_date( $year );
+		}
+
+		if ( 'postseason' === $season_type ) {
+			$full = $this->fetch_guardians_standings_normalized( $year, 'postseason', null, self::API_ARCHIVE_CACHE_TTL );
+			if ( is_wp_error( $full ) || ( is_array( $full ) && ! empty( $full['_empty_records'] ) ) ) {
+				$fallback = $this->get_postseason_record_from_schedule( $year );
+				if ( is_wp_error( $fallback ) ) {
+					return is_wp_error( $full ) ? $full : $fallback;
+				}
+				return $this->map_team_record_to_archive_stats( $fallback['standings_row'], $year, 'postseason', $fallback['division_name'] );
+			}
+			unset( $full['_empty_records'], $full['_team_record_raw'] );
+			return $this->map_full_standings_to_archive_stats( $full, $year, 'postseason' );
+		}
+
+		$full = $this->fetch_guardians_standings_normalized( $year, $season_type, $date, self::API_ARCHIVE_CACHE_TTL );
+		if ( is_wp_error( $full ) ) {
+			return $full;
+		}
+		if ( ! empty( $full['_empty_records'] ) ) {
+			return new WP_Error( 'basebelles_api_empty', 'Standings data was empty.' );
+		}
+		unset( $full['_empty_records'], $full['_team_record_raw'] );
+
+		return $this->map_full_standings_to_archive_stats( $full, $year, $season_type );
+	}
+
+	/**
+	 * Load standings from the API and return the same shape as the legacy get_guardians_standings array.
+	 *
+	 * @param int         $year         Season year.
+	 * @param string      $season_type  Standings type.
+	 * @param string|null $date         Optional YYYY-MM-DD snapshot (Spring Training).
+	 * @param int         $cache_ttl    Transient TTL in seconds.
+	 * @return array|WP_Error
+	 */
+	private function fetch_guardians_standings_normalized( $year, $season_type, $date = null, $cache_ttl = self::API_CACHE_TTL ) {
+		$allowed_types = array(
+			'springTraining',
+			'regularSeason',
+			'wildCard',
+			'postseason',
+		);
+		if ( ! in_array( $season_type, $allowed_types, true ) ) {
+			$season_type = 'regularSeason';
+		}
+
+		$league_id = ( 'springTraining' === $season_type ) ? self::CL_LEAGUE_ID : self::AL_LEAGUE_ID;
+		$query     = array(
+			'leagueId'       => $league_id,
+			'season'         => (int) $year,
+			'standingsTypes' => $season_type,
+			'hydrate'        => 'division',
+		);
+
+		if ( null !== $date && '' !== $date ) {
+			$query['date'] = $date;
+		}
+
+		$data = $this->request_json( 'standings', $query, $cache_ttl );
 
 		if ( is_wp_error( $data ) ) {
 			return $data;
 		}
 
 		if ( empty( $data['records'] ) || ! is_array( $data['records'] ) ) {
-			return new WP_Error( 'basebelles_api_empty', 'Standings data was empty.' );
+			return array(
+				'_empty_records' => true,
+			);
 		}
 
 		$team_record = $this->find_team_record( $data['records'], self::GUARDIANS_TEAM_ID );
@@ -123,9 +217,215 @@ class Basebelles_API {
 			'home'                 => $this->format_split_record( $split_records, 'home' ),
 			'away'                 => $this->format_split_record( $split_records, 'away' ),
 			'over_500'             => $this->format_split_record( $split_records, 'winners' ),
-			'season'               => $settings['season'],
-			'season_type'          => $settings['season_type'],
+			'season'               => (int) $year,
+			'season_type'          => $season_type,
 			'last_updated'         => $team_record['lastUpdated'] ?? '',
+			'_team_record_raw'     => $team_record,
+		);
+	}
+
+	/**
+	 * Last calendar day of Guardians spring training for a season (for standings snapshot).
+	 *
+	 * @param int $year Season year.
+	 * @return string YYYY-MM-DD.
+	 */
+	private function get_spring_training_freeze_date( $year ) {
+		$year = (int) $year;
+		$data = $this->request_json(
+			'schedule',
+			array(
+				'sportId'  => 1,
+				'teamId'   => self::GUARDIANS_TEAM_ID,
+				'season'   => $year,
+				'gameType' => 'S',
+			),
+			self::API_ARCHIVE_CACHE_TTL
+		);
+
+		$max_date = '';
+		if ( ! is_wp_error( $data ) && ! empty( $data['dates'] ) && is_array( $data['dates'] ) ) {
+			foreach ( $data['dates'] as $row ) {
+				$d = (string) ( $row['date'] ?? '' );
+				if ( '' !== $d && $d > $max_date ) {
+					$max_date = $d;
+				}
+			}
+		}
+
+		if ( '' !== $max_date ) {
+			return $max_date;
+		}
+
+		$options_year = (int) $this->get_option_value( 'season', (int) gmdate( 'Y' ) );
+		if ( $year === $options_year && function_exists( 'get_field' ) ) {
+			$st = get_field( 'spring_training', 'option' );
+			if ( is_array( $st ) && ! empty( $st['end'] ) && 'TBD' !== $st['end'] ) {
+				$parsed = $this->normalize_game_date( (string) $st['end'] );
+				if ( (int) substr( $parsed, 0, 4 ) === $year ) {
+					return $parsed;
+				}
+			}
+		}
+
+		// Conservative default when schedule is not yet published.
+		return $year . '-03-31';
+	}
+
+	/**
+	 * When postseason standings are empty, derive W–L from schedule (non-R/S games).
+	 *
+	 * @param int $year Season year.
+	 * @return array|WP_Error team_record-shaped array plus division_name, or error.
+	 */
+	private function get_postseason_record_from_schedule( $year ) {
+		$data = $this->request_json(
+			'schedule',
+			array(
+				'sportId'   => 1,
+				'teamId'    => self::GUARDIANS_TEAM_ID,
+				'season'    => (int) $year,
+				'startDate' => $year . '-04-01',
+				'endDate'   => $year . '-11-30',
+			),
+			self::API_ARCHIVE_CACHE_TTL
+		);
+
+		if ( is_wp_error( $data ) ) {
+			return $data;
+		}
+
+		$wins             = 0;
+		$losses           = 0;
+		$runs_scored      = 0;
+		$runs_allowed     = 0;
+		$postseason_games = 0;
+
+		foreach ( $data['dates'] ?? array() as $day ) {
+			foreach ( $day['games'] ?? array() as $game ) {
+				if ( ! is_array( $game ) ) {
+					continue;
+				}
+				$gtype = (string) ( $game['gameType'] ?? '' );
+				if ( 'R' === $gtype || 'S' === $gtype ) {
+					continue;
+				}
+				$status = (string) ( $game['status']['abstractGameState'] ?? '' );
+				if ( 'Final' !== $status ) {
+					continue;
+				}
+
+				$is_home   = self::GUARDIANS_TEAM_ID === (int) ( $game['teams']['home']['team']['id'] ?? 0 );
+				$team_side = $is_home ? 'home' : 'away';
+				$opp_side  = $is_home ? 'away' : 'home';
+				$team_r    = (int) ( $game['teams'][ $team_side ]['score'] ?? 0 );
+				$opp_r     = (int) ( $game['teams'][ $opp_side ]['score'] ?? 0 );
+				$is_winner = ! empty( $game['teams'][ $team_side ]['isWinner'] );
+
+				++$postseason_games;
+				if ( $is_winner ) {
+					++$wins;
+				} else {
+					++$losses;
+				}
+				$runs_scored  += $team_r;
+				$runs_allowed += $opp_r;
+			}
+		}
+
+		if ( $postseason_games < 1 ) {
+			return new WP_Error( 'basebelles_api_postseason_empty', 'No postseason games found for this season.' );
+		}
+
+		$rd      = $runs_scored - $runs_allowed;
+		$pct_val = ( $wins + $losses ) > 0 ? $wins / ( $wins + $losses ) : 0;
+		$pct_str = number_format( $pct_val, 3, '.', '' );
+		if ( $pct_val < 1.0 ) {
+			$pct_str = substr( $pct_str, 1 );
+		}
+
+		$standings_row = array(
+			'wins'               => $wins,
+			'losses'             => $losses,
+			'winning_percentage' => $pct_str,
+			'run_differential'   => $this->format_run_differential( $rd ),
+			'games_back'         => '—',
+			'last_ten'           => '—',
+			'streak'             => '—',
+			'division_rank'      => '',
+			'division_name'      => 'Postseason',
+			'summary'            => 'Postseason',
+		);
+
+		return array(
+			'standings_row' => $standings_row,
+			'division_name' => 'Postseason',
+		);
+	}
+
+	/**
+	 * @param array  $full Full normalized standings from fetch_guardians_standings_normalized.
+	 * @param int    $year Season year.
+	 * @param string $season_type API season type.
+	 * @return array
+	 */
+	private function map_full_standings_to_archive_stats( $full, $year, $season_type ) {
+		return $this->map_team_record_to_archive_stats(
+			$full,
+			$year,
+			$season_type,
+			$full['division_name'] ?? 'AL Central'
+		);
+	}
+
+	/**
+	 * Build archive stat keys for the snapshot block.
+	 *
+	 * @param array  $full Full standings row or compatible array.
+	 * @param int    $year Season year.
+	 * @param string $season_type API season type.
+	 * @param string $division_override Division label from standings (or Postseason for schedule fallback).
+	 * @return array
+	 */
+	private function map_team_record_to_archive_stats( $full, $year, $season_type, $division_override ) {
+		$w   = (int) ( $full['wins'] ?? 0 );
+		$l   = (int) ( $full['losses'] ?? 0 );
+		$pct = (string) ( $full['winning_percentage'] ?? '.000' );
+		$rd  = (string) ( $full['run_differential'] ?? '0' );
+		$gb  = (string) ( $full['games_back'] ?? '-' );
+		$lt  = (string) ( $full['last_ten'] ?? '—' );
+		$stk = (string) ( $full['streak'] ?? '-' );
+
+		if ( 'springTraining' === $season_type ) {
+			$division = 'Cactus League';
+			$rank_raw = (string) ( $full['division_rank'] ?? '' );
+			$rank     = ctype_digit( $rank_raw )
+				? $this->format_ordinal( (int) $rank_raw ) . ' (Cactus)'
+				: ( $rank_raw ? $rank_raw . ' (Cactus)' : '—' );
+		} elseif ( 'postseason' === $season_type ) {
+			$division = $division_override ? $division_override : 'Postseason';
+			$rank_raw = (string) ( $full['division_rank'] ?? '' );
+			$rank     = ctype_digit( $rank_raw ) ? $this->format_ordinal( (int) $rank_raw ) . ' (' . $division . ')' : 'Postseason';
+		} else {
+			$division = (string) ( $full['division_name'] ?? 'AL Central' );
+			$rank_raw = (string) ( $full['division_rank'] ?? '' );
+			$rank     = ctype_digit( $rank_raw )
+				? $this->format_ordinal( (int) $rank_raw ) . ' (' . $division . ')'
+				: ( $full['summary'] ?? '—' );
+		}
+
+		return array(
+			'wins'        => $w,
+			'losses'      => $l,
+			'pct'         => $pct,
+			'run_diff'    => $rd,
+			'rank'        => $rank,
+			'division'    => $division,
+			'games_back'  => $gb,
+			'last_ten'    => $lt,
+			'streak'      => $stk,
+			'season'      => (int) $year,
+			'season_type' => $season_type,
 		);
 	}
 
@@ -366,8 +666,11 @@ class Basebelles_API {
 	 * @return array|WP_Error
 	 */
 	public function request_json( $endpoint, $query_args = array(), $expiration = self::API_CACHE_TTL ) {
-		$url       = $this->build_url( $endpoint, $query_args );
-		$cache_key = 'basebelles_api_' . md5( $url );
+		$url        = $this->build_url( $endpoint, $query_args );
+		$expiration = max( 1, (int) $expiration );
+		// Bucket by TTL window so data cannot stay fresh past the intended horizon if a persistent
+		// object cache (e.g. Docket Cache) fails to enforce transient expiration.
+		$cache_key = 'basebelles_api_' . md5( $url ) . '_' . (int) floor( time() / $expiration );
 		$cached    = get_transient( $cache_key );
 
 		if ( false !== $cached ) {

--- a/team-info/list.json
+++ b/team-info/list.json
@@ -6,7 +6,8 @@
 		"city": "Los Angeles",
 		"state": "CA",
 		"country": "USA",
-		"league": "AL West"
+		"league": "AL West",
+		"mlb_team_id": 108
 	},
 	"astros": {
 		"name": "Houston Astros",
@@ -15,16 +16,18 @@
 		"city": "Houston",
 		"state": "TX",
 		"country": "USA",
-		"league": "AL West"
+		"league": "AL West",
+		"mlb_team_id": 117
 	},
 	"athletics": {
-		"name": "Oakland Athletics",
+		"name": "Athletics",
 		"short_name": "Athletics",
 		"abbreviation": "OAK",
-		"city": "Oakland",
+		"city": "Sacremento",
 		"state": "CA",
 		"country": "USA",
-		"league": "AL West"
+		"league": "AL West",
+		"mlb_team_id": 133
 	},
 	"blue-jays": {
 		"name": "Toronto Blue Jays",
@@ -33,7 +36,8 @@
 		"city": "Toronto",
 		"state": "ON",
 		"country": "Canada",
-		"league": "AL East"
+		"league": "AL East",
+		"mlb_team_id": 141
 	},
 	"braves": {
 		"name": "Atlanta Braves",
@@ -42,7 +46,8 @@
 		"city": "Atlanta",
 		"state": "GA",
 		"country": "USA",
-		"league": "NL East"
+		"league": "NL East",
+		"mlb_team_id": 144
 	},
 	"brewers": {
 		"name": "Milwaukee Brewers",
@@ -51,7 +56,8 @@
 		"city": "Milwaukee",
 		"state": "WI",
 		"country": "USA",
-		"league": "NL Central"
+		"league": "NL Central",
+		"mlb_team_id": 158
 	},
 	"cardinals": {
 		"name": "St. Louis Cardinals",
@@ -60,7 +66,8 @@
 		"city": "St. Louis",
 		"state": "MO",
 		"country": "USA",
-		"league": "NL Central"
+		"league": "NL Central",
+		"mlb_team_id": 138
 	},
 	"cubs": {
 		"name": "Chicago Cubs",
@@ -69,7 +76,8 @@
 		"city": "Chicago",
 		"state": "IL",
 		"country": "USA",
-		"league": "NL Central"
+		"league": "NL Central",
+		"mlb_team_id": 112
 	},
 	"d-backs": {
 		"name": "Arizona Diamondbacks",
@@ -78,7 +86,8 @@
 		"city": "Phoenix",
 		"state": "AZ",
 		"country": "USA",
-		"league": "NL West"
+		"league": "NL West",
+		"mlb_team_id": 109
 	},
 	"dodgers": {
 		"name": "Los Angeles Dodgers",
@@ -87,7 +96,8 @@
 		"city": "Los Angeles",
 		"state": "CA",
 		"country": "USA",
-		"league": "NL West"
+		"league": "NL West",
+		"mlb_team_id": 119
 	},
 	"giants": {
 		"name": "San Francisco Giants",
@@ -96,7 +106,8 @@
 		"city": "San Francisco",
 		"state": "CA",
 		"country": "USA",
-		"league": "NL West"
+		"league": "NL West",
+		"mlb_team_id": 137
 	},
 	"guardians": {
 		"name": "Cleveland Guardians",
@@ -105,7 +116,8 @@
 		"city": "Cleveland",
 		"state": "OH",
 		"country": "USA",
-		"league": "AL Central"
+		"league": "AL Central",
+		"mlb_team_id": 114
 	},
 	"mariners": {
 		"name": "Seattle Mariners",
@@ -114,7 +126,8 @@
 		"city": "Seattle",
 		"state": "WA",
 		"country": "USA",
-		"league": "AL West"
+		"league": "AL West",
+		"mlb_team_id": 136
 	},
 	"marlins": {
 		"name": "Miami Marlins",
@@ -123,7 +136,8 @@
 		"city": "Miami",
 		"state": "FL",
 		"country": "USA",
-		"league": "NL East"
+		"league": "NL East",
+		"mlb_team_id": 146
 	},
 	"mets": {
 		"name": "New York Mets",
@@ -132,7 +146,8 @@
 		"city": "New York",
 		"state": "NY",
 		"country": "USA",
-		"league": "NL East"
+		"league": "NL East",
+		"mlb_team_id": 121
 	},
 	"nationals": {
 		"name": "Washington Nationals",
@@ -141,7 +156,8 @@
 		"city": "Washington",
 		"state": "DC",
 		"country": "USA",
-		"league": "NL East"
+		"league": "NL East",
+		"mlb_team_id": 120
 	},
 	"orioles": {
 		"name": "Baltimore Orioles",
@@ -150,7 +166,8 @@
 		"city": "Baltimore",
 		"state": "MD",
 		"country": "USA",
-		"league": "AL East"
+		"league": "AL East",
+		"mlb_team_id": 110
 	},
 	"padres": {
 		"name": "San Diego Padres",
@@ -159,7 +176,8 @@
 		"city": "San Diego",
 		"state": "CA",
 		"country": "USA",
-		"league": "NL West"
+		"league": "NL West",
+		"mlb_team_id": 135
 	},
 	"phillies": {
 		"name": "Philadelphia Phillies",
@@ -168,7 +186,8 @@
 		"city": "Philadelphia",
 		"state": "PA",
 		"country": "USA",
-		"league": "NL East"
+		"league": "NL East",
+		"mlb_team_id": 143
 	},
 	"pirates": {
 		"name": "Pittsburgh Pirates",
@@ -177,7 +196,8 @@
 		"city": "Pittsburgh",
 		"state": "PA",
 		"country": "USA",
-		"league": "NL Central"
+		"league": "NL Central",
+		"mlb_team_id": 134
 	},
 	"rangers": {
 		"name": "Texas Rangers",
@@ -186,7 +206,8 @@
 		"city": "Arlington",
 		"state": "TX",
 		"country": "USA",
-		"league": "AL West"
+		"league": "AL West",
+		"mlb_team_id": 140
 	},
 	"rays": {
 		"name": "Tampa Bay Rays",
@@ -195,7 +216,8 @@
 		"city": "Tampa",
 		"state": "FL",
 		"country": "USA",
-		"league": "AL East"
+		"league": "AL East",
+		"mlb_team_id": 139
 	},
 	"red-sox": {
 		"name": "Boston Red Sox",
@@ -204,7 +226,8 @@
 		"city": "Boston",
 		"state": "MA",
 		"country": "USA",
-		"league": "AL East"
+		"league": "AL East",
+		"mlb_team_id": 111
 	},
 	"reds": {
 		"name": "Cincinnati Reds",
@@ -213,7 +236,8 @@
 		"city": "Cincinnati",
 		"state": "OH",
 		"country": "USA",
-		"league": "NL Central"
+		"league": "NL Central",
+		"mlb_team_id": 113
 	},
 	"rockies": {
 		"name": "Colorado Rockies",
@@ -222,7 +246,8 @@
 		"city": "Denver",
 		"state": "CO",
 		"country": "USA",
-		"league": "NL West"
+		"league": "NL West",
+		"mlb_team_id": 115
 	},
 	"royals": {
 		"name": "Kansas City Royals",
@@ -231,7 +256,8 @@
 		"city": "Kansas City",
 		"state": "MO",
 		"country": "USA",
-		"league": "AL Central"
+		"league": "AL Central",
+		"mlb_team_id": 118
 	},
 	"tigers": {
 		"name": "Detroit Tigers",
@@ -240,7 +266,8 @@
 		"city": "Detroit",
 		"state": "MI",
 		"country": "USA",
-		"league": "AL Central"
+		"league": "AL Central",
+		"mlb_team_id": 116
 	},
 	"twins": {
 		"name": "Minnesota Twins",
@@ -249,7 +276,8 @@
 		"city": "Minneapolis",
 		"state": "MN",
 		"country": "USA",
-		"league": "AL Central"
+		"league": "AL Central",
+		"mlb_team_id": 142
 	},
 	"white-sox": {
 		"name": "Chicago White Sox",
@@ -258,7 +286,8 @@
 		"city": "Chicago",
 		"state": "IL",
 		"country": "USA",
-		"league": "AL Central"
+		"league": "AL Central",
+		"mlb_team_id": 145
 	},
 	"yankees": {
 		"name": "New York Yankees",
@@ -267,6 +296,7 @@
 		"city": "New York",
 		"state": "NY",
 		"country": "USA",
-		"league": "AL East"
+		"league": "AL East",
+		"mlb_team_id": 147
 	}
 }


### PR DESCRIPTION
This PR adds a **Season Snapshot** block for season-type archives, extends the API so standings and stats can target a specific season year (with caching tuned for archives), and tightens **Today’s game** and **Season header** UI. It also aligns the season archive query with `season_year` (query var and query string) and refreshes team metadata in `team-info/list.json`.

### Features / changes

- **Season Snapshot block:** Register `acf/basebelles-season-stats-header` with styles for a summary stats bar (record, rank, run diff) on archive pages.
- **API:** Add archive-oriented helpers (`get_season_archive_stats`, refactored `fetch_guardians_standings_normalized`), optional year on `get_guardians_standings`, longer-lived cache for archive snapshots, postseason fallback when standings are empty, and spring-training date handling where needed.
- **Main query:** In `pre_get_posts`, bail early for admin or non–main queries; on `season-type` tax archives, read `season_year` from the query var and from `$_GET['season_year']` (replacing `year`).
- **Today’s game:** Style final score by winner (`guards-win` / `oppo-win`), adjust layout/CSS for responsiveness, and fix the image markup in `render.php`.
- **Season header:** Update block icon metadata and small render tweaks.
- **Teams data:** Expand/update MLB team IDs and structure in `team-info/list.json`.
- **Global CSS:** Minor `basebelles.css` adjustments.

### Breaking / compatibility note

- URLs or integrations that used **`?year=`** or the **`year`** query var for season-type archives must switch to **`season_year`** (query var and GET parameter) to match the new behavior.