### PR TITLE
feat(acf): sync JSON on deploy, refactor loader, hide admin in prod

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,9 +25,22 @@ jobs:
         env:
           SSH_PRIVATE_KEY: ${{ secrets.BELLES_SSH_KEY }}
           # Standard rsync flags: archive, compress, verbose, delete extraneous
-          ARGS: "-azv --delete" 
+          ARGS: "-azv --delete"
           REMOTE_HOST: ${{ secrets.BELLES_HOST }}
           REMOTE_USER: ${{ secrets.BELLES_USER }}
           # Pathing for DreamHost standalone
           TARGET: "/home/${{ secrets.BELLES_USER }}/${{ secrets.BELLES_FOLDER }}/wp-content/plugins/basebelles/"
           EXCLUDE: "/.git/, /.github/, /node_modules/, .DS_Store"
+
+      - name: Sync ACF JSON on Server
+        uses: appleboy/ssh-action@v1.2.5
+        with:
+          host: ${{ secrets.BELLES_HOST }}
+          username: ${{ secrets.BELLES_USER }}
+          key: ${{ secrets.BELLES_SSH_KEY }}
+          script: |
+            # Navigate to the WordPress root
+            cd /home/${{ secrets.BELLES_USER }}/${{ secrets.BELLES_FOLDER }}
+
+            # Run the ACF Sync
+            /usr/bin/wp acf json sync --quiet

--- a/acf-json/group_69c70525044fc.json
+++ b/acf-json/group_69c70525044fc.json
@@ -493,5 +493,6 @@
     "show_in_rest": 0,
     "display_title": "",
     "allow_ai_access": false,
-    "ai_description": ""
+    "ai_description": "",
+    "modified": 1744754400
 }

--- a/acf-json/group_69c9b611cc123.json
+++ b/acf-json/group_69c9b611cc123.json
@@ -205,5 +205,6 @@
     "show_in_rest": 0,
     "display_title": "",
     "allow_ai_access": false,
-    "ai_description": ""
+    "ai_description": "",
+    "modified": 1744754400
 }

--- a/acf-json/group_69cd81d38a341.json
+++ b/acf-json/group_69cd81d38a341.json
@@ -408,5 +408,6 @@
     "show_in_rest": 0,
     "display_title": "",
     "allow_ai_access": false,
-    "ai_description": ""
+    "ai_description": "",
+    "modified": 1744754400
 }

--- a/acf-json/group_69cd84b09788e.json
+++ b/acf-json/group_69cd84b09788e.json
@@ -52,5 +52,6 @@
     "show_in_rest": 0,
     "display_title": "",
     "allow_ai_access": false,
-    "ai_description": ""
+    "ai_description": "",
+    "modified": 1744754400
 }

--- a/acf-json/group_69cd93a2d7616.json
+++ b/acf-json/group_69cd93a2d7616.json
@@ -43,5 +43,6 @@
     "show_in_rest": 1,
     "display_title": "",
     "allow_ai_access": false,
-    "ai_description": ""
+    "ai_description": "",
+    "modified": 1744754400
 }

--- a/acf-json/group_69d69d470fc5d.json
+++ b/acf-json/group_69d69d470fc5d.json
@@ -45,5 +45,6 @@
     "acfe_autosync": "",
     "acfe_form": 0,
     "acfe_meta": "",
-    "acfe_note": ""
+    "acfe_note": "",
+    "modified": 1744754400
 }

--- a/acf-json/taxonomy_69d026d1349b6.json
+++ b/acf-json/taxonomy_69d026d1349b6.json
@@ -72,5 +72,6 @@
     "meta_box_cb": "",
     "meta_box_sanitize_cb": "",
     "allow_ai_access": false,
-    "ai_description": ""
+    "ai_description": "",
+    "modified": 1744754400
 }

--- a/acf-json/taxonomy_69d2a3cfdb2ce.json
+++ b/acf-json/taxonomy_69d2a3cfdb2ce.json
@@ -72,5 +72,6 @@
     "meta_box_cb": "",
     "meta_box_sanitize_cb": "",
     "allow_ai_access": false,
-    "ai_description": ""
+    "ai_description": "",
+    "modified": 1744754400
 }

--- a/acf-json/ui_options_page_69cd815c34940.json
+++ b/acf-json/ui_options_page_69cd815c34940.json
@@ -21,5 +21,6 @@
     "capability": "edit_posts",
     "data_storage": "options",
     "post_id": "",
-    "autoload": 0
+    "autoload": 0,
+    "modified": 1744754400
 }

--- a/basebelles.php
+++ b/basebelles.php
@@ -26,6 +26,7 @@ class Basebelles {
 
 		// ACF
 		require_once 'blocks/class-acf-json.php';
+		new Basebelles_ACF_JSON();
 
 		// Quality of Life
 		add_action( 'pre_ping', array( $this, 'no_self_ping' ) );

--- a/basebelles.php
+++ b/basebelles.php
@@ -24,8 +24,8 @@ class Basebelles {
 	public function __construct() {
 		self::$version = '1.2.2';
 
-		require_once __DIR__ . '/blocks/class-acf-json.php';
-		Basebelles_ACF_JSON::register_hooks();
+		// ACF
+		require_once 'blocks/class-acf-json.php';
 
 		// Quality of Life
 		add_action( 'pre_ping', array( $this, 'no_self_ping' ) );

--- a/blocks/class-acf-json.php
+++ b/blocks/class-acf-json.php
@@ -16,6 +16,21 @@ defined( 'ABSPATH' ) || exit;
  */
 class Basebelles_ACF_JSON {
 
+	public static $version;
+
+	/**
+	 * Constructor
+	 *
+	 * @return void
+	 */
+	public function __construct() {
+		self::$version = Basebelles::$version;
+
+		add_filter( 'acf/settings/save_json', array( $this, 'save_json_path' ) );
+		add_filter( 'acf/settings/load_json', array( $this, 'load_json_paths' ) );
+		add_filter( 'acf/json/load_paths', array( $this, 'load_json_paths' ) );
+	}
+
 	/**
 	 * Absolute path to the acf-json directory (trailing slash).
 	 *
@@ -24,16 +39,6 @@ class Basebelles_ACF_JSON {
 	public static function json_dir() {
 		$json_dir = plugin_dir_path( __DIR__ ) . 'acf-json/';
 		return $json_dir;
-	}
-
-	/**
-	 * Register filters with ACF.
-	 *
-	 * @return void
-	 */
-	public static function register_hooks() {
-		add_filter( 'acf/settings/save_json', array( __CLASS__, 'save_json_path' ) );
-		add_filter( 'acf/settings/load_json', array( __CLASS__, 'load_json_paths' ) );
 	}
 
 	/**
@@ -48,30 +53,20 @@ class Basebelles_ACF_JSON {
 	}
 
 	/**
-	 * Additional load paths for Local JSON (theme paths remain; plugin JSON is appended).
-	 *
-	 * @param string[] $paths Load paths.
-	 * @return string[]
-	 */
-	public static function load_json_paths( $paths ) {
-		$paths[] = self::json_dir();
-		return $paths;
-	}
-
-	/**
 	 * ACF 6.2+: same load list as `acf/settings/load_json`, applied in `ACF_Local_JSON::get_load_paths()`.
 	 * Ensures WP-CLI (`wp acf json sync`, `wp acf json status`) sees plugin JSON, not only the theme folder.
 	 *
 	 * @param string[] $paths Load paths.
 	 * @return string[]
 	 */
-	public static function json_load_paths( $paths ) {
-		// Remove the original path (optional).
-		unset($paths[0]);
-
+	public static function load_json_paths( $paths ) {
 		// Append the new path and return it.
 		$paths[] = self::json_dir();
+
+		error_log( 'load_json_paths: ' . print_r( $paths, true ) );
 
 		return $paths;
 	}
 }
+
+new Basebelles_ACF_JSON();

--- a/blocks/class-acf-json.php
+++ b/blocks/class-acf-json.php
@@ -16,19 +16,15 @@ defined( 'ABSPATH' ) || exit;
  */
 class Basebelles_ACF_JSON {
 
-	public static $version;
-
 	/**
 	 * Constructor
 	 *
 	 * @return void
 	 */
 	public function __construct() {
-		self::$version = Basebelles::$version;
-
-		add_filter( 'acf/settings/save_json', array( $this, 'save_json_path' ) );
-		add_filter( 'acf/settings/load_json', array( $this, 'load_json_paths' ) );
-		add_filter( 'acf/json/load_paths', array( $this, 'load_json_paths' ) );
+		add_filter( 'acf/settings/save_json', array( __CLASS__, 'save_json_path' ) );
+		add_filter( 'acf/settings/load_json', array( __CLASS__, 'load_json_paths' ) );
+		add_filter( 'acf/json/load_paths', array( __CLASS__, 'load_json_paths' ) );
 
 		// Only hide the UI on Production
 		if ( defined( 'WP_ENVIRONMENT_TYPE' ) && WP_ENVIRONMENT_TYPE === 'production' ) {
@@ -71,5 +67,3 @@ class Basebelles_ACF_JSON {
 		return $paths;
 	}
 }
-
-new Basebelles_ACF_JSON();

--- a/blocks/class-acf-json.php
+++ b/blocks/class-acf-json.php
@@ -29,6 +29,11 @@ class Basebelles_ACF_JSON {
 		add_filter( 'acf/settings/save_json', array( $this, 'save_json_path' ) );
 		add_filter( 'acf/settings/load_json', array( $this, 'load_json_paths' ) );
 		add_filter( 'acf/json/load_paths', array( $this, 'load_json_paths' ) );
+
+		// Only hide the UI on Production
+		if ( defined( 'WP_ENVIRONMENT_TYPE' ) && WP_ENVIRONMENT_TYPE === 'production' ) {
+			add_filter( 'acf/settings/show_admin', '__return_false' );
+		}
 	}
 
 	/**

--- a/blocks/class-acf-json.php
+++ b/blocks/class-acf-json.php
@@ -63,8 +63,6 @@ class Basebelles_ACF_JSON {
 		// Append the new path and return it.
 		$paths[] = self::json_dir();
 
-		error_log( 'load_json_paths: ' . print_r( $paths, true ) );
-
 		return $paths;
 	}
 }


### PR DESCRIPTION
This PR tightens how the plugin registers ACF Local JSON (constructor-based hooks, single load-path handler, instantiation at load time), aligns exported JSON with ACF’s `modified` field, and automates database sync after deploy. It also hides the ACF admin UI in production when `WP_ENVIRONMENT_TYPE` is `production`.

### Features / changes

- **ACF JSON class:** Refactor `Basebelles_ACF_JSON` to use an instance constructor for filters; wire `acf/settings/save_json`, `acf/settings/load_json`, and `acf/json/load_paths` to one `load_json_paths` implementation; drop the previous `unset( $paths[0] )` behavior so WP-CLI (`wp acf json sync` / `status`) sees plugin JSON consistently.
- **Bootstrap:** Load `blocks/class-acf-json.php` via a relative `require_once`; rely on `new Basebelles_ACF_JSON()` at the bottom of that file instead of `Basebelles_ACF_JSON::register_hooks()`.
- **Local JSON files:** Add `modified` timestamps to all committed `acf-json/*.json` definitions.
- **Production:** When `WP_ENVIRONMENT_TYPE === 'production'`, filter `acf/settings/show_admin` to hide the ACF admin UI.
- **Deploy:** After rsync in `.github/workflows/deploy.yaml`, add an SSH step that `cd`s to the WordPress root and runs `/usr/bin/wp acf json sync --quiet`.
